### PR TITLE
Permit disabling Fortran Interfaces 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 Version 0.44.0 (In progress, 2015)
 
+  * Added '--disable-fortran' configuration option
   * Adding fortran interface for 4d cns
   * fixed a bug in the 2d temporal interfaces (Issue #20)
   * two workarounds prevent segfaults at program exit (fixes Intel 12.1)

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 Version 0.44.0 (In progress, 2015)
 
-  * Added '--disable-fortran' configuration option
+  * Added '--enable-fortran-interfaces' configuration option
   * Adding fortran interface for 4d cns
   * fixed a bug in the 2d temporal interfaces (Issue #20)
   * two workarounds prevent segfaults at program exit (fixes Intel 12.1)

--- a/README
+++ b/README
@@ -15,11 +15,11 @@ MASA currently supports later versions of the GNU, Intel, and PGI
 family of compilers.
 
 Regression tests are routinely performed against the following
-compiler versions:
+compilers:
 
-PGI 11.5
-GNU 4.5
-Intel 11.1
+PGI
+GNU
+Intel
 
 ------------------
 TO BUILD:

--- a/configure.ac
+++ b/configure.ac
@@ -42,10 +42,6 @@ AC_SUBST([PACKAGE_URL])
 AX_CC_MINOPT	# request minimum optimization level for C	
 AX_CXX_MINOPT	# request minimum optimization level for CXX
 
-# set suffix to .F90 to get CPP support for testing vendor Fortran compiler
-AC_FC_SRCEXT([F90]) 
-AX_FC_MINOPT	# request minimum optimization level for FC
-
 # ---------------------------------------------
 # Enable/Disable -Wall (Warn all)
 # ---------------------------------------------
@@ -60,8 +56,6 @@ AC_DISABLE_STATIC
 
 AC_PROG_CC
 AC_PROG_CXX
-AC_PROG_LIBTOOL
-AM_SANITY_CHECK
 
 # ----------------------------
 # We may need the math library
@@ -78,13 +72,22 @@ AC_LANG_POP([C])
 FORTRAN_INTERFACES=0
 AC_ARG_ENABLE([fortran-interfaces], AC_HELP_STRING([--enable-fortran-interfaces],[enable fortran support]),
 [
-#AC_PROG_FC
-#AC_PROG_F77
-
+dnl set suffix to .F90 to get CPP support for testing vendor Fortran compiler
+AC_FC_SRCEXT([F90]) 
+dnl request minimum optimization level for FC
+AX_FC_MINOPT
+AC_PROG_F77()
+AC_PROG_FC()
 FORTRAN_INTERFACES=1
-AC_DEFINE(FORTRAN_INTERFACES,1,[Define if python interfaces enabled])
+AC_DEFINE(FORTRAN_INTERFACES,1,[Define if Fortran interfaces enabled])
 ],[])
 AM_CONDITIONAL(FORT_ENABLED,[test "x$FORTRAN_INTERFACES" = x1]) 
+
+#
+# now call libtool
+#
+AC_PROG_LIBTOOL
+AM_SANITY_CHECK
 
 
 # ---------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -60,8 +60,6 @@ AC_DISABLE_STATIC
 
 AC_PROG_CC
 AC_PROG_CXX
-AC_PROG_FC
-AC_PROG_F77
 AC_PROG_LIBTOOL
 AM_SANITY_CHECK
 
@@ -73,6 +71,21 @@ AC_SEARCH_LIBS([cos], [m], [], [
     AC_MSG_ERROR([unable to find the cos() function])
 ])
 AC_LANG_POP([C])
+
+# ---------------------------------------------
+# enable fortran interfaces
+# ---------------------------------------------
+FORTRAN_INTERFACES=0
+AC_ARG_ENABLE([fortran-interfaces], AC_HELP_STRING([--enable-fortran-interfaces],[enable fortran support]),
+[
+#AC_PROG_FC
+#AC_PROG_F77
+
+FORTRAN_INTERFACES=1
+AC_DEFINE(FORTRAN_INTERFACES,1,[Define if python interfaces enabled])
+],[])
+AM_CONDITIONAL(FORT_ENABLED,[test "x$FORTRAN_INTERFACES" = x1]) 
+
 
 # ---------------------------------------------
 # enable python interfaces with SWIG

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -15,7 +15,11 @@ noinst_PROGRAMS  = MASAshell display_solutions euler_example navierstokes burger
 noinst_PROGRAMS += rans_sa fans_sa fans_sa_finite_d fans_sa_wall radiation euler_chem 
 noinst_PROGRAMS += euler_transient heat_example switch ablation_example
 noinst_PROGRAMS += c_heat_example c_euler_example c_laplace_example sod
+
+if FORT_ENABLED
 noinst_PROGRAMS += f_cns f_cns_4d f_euler f_laplace f_insh
+endif
+
 noinst_PROGRAMS += cp_gaussian
 noinst_PROGRAMS += laplace_example
 
@@ -63,6 +67,7 @@ example_DATA             += c_heat_example.c c_euler_example.c
 # ----------------- 
 #    Pf'ortran
 # ----------------- 
+if FORT_ENABLED
 
 f_laplace_SOURCES         = f_laplace.f90
 f_laplace_LDADD           = -lfmasa
@@ -86,6 +91,7 @@ f_insh_LIBTOOLFLAGS        = --tag=FC
 
 example_DATA             += f_euler.f90
 
+endif
 
 #----------------------
 # Regression Tests
@@ -113,14 +119,18 @@ TESTS                      = init.sh              \
 			     c_init.sh            \
                              c_euler_example      \
                              c_laplace_example    \
-                             c_heat_example       \
-			     f_init.sh            \
+                             c_heat_example
+
+if FORT_ENABLED
+TESTS                     += f_init.sh            \
                              f_laplace            \
                              f_euler              \
                              f_cns                \
                              f_cns_4d             \
-                             f_insh               \
-                             finalize.sh
+                             f_insh 
+endif
+
+TESTS                     += finalize.sh
 
 EXTRA_DIST                 = init.sh              \
 			     c_init.sh            \

--- a/m4/config_summary.m4
+++ b/m4/config_summary.m4
@@ -25,8 +25,6 @@ echo C++ compiler....................   : $CXX
 echo C++ compiler flags..............   : $CXXFLAGS
 echo C compiler......................   : $CC
 echo C compiler flags................   : $CFLAGS
-echo Fortran compiler................   : $FC
-echo Fortran compiler flags..........   : $FCFLAGS
 echo Install dir.....................   : $prefix 
 echo Build user......................   : $USER
 echo Build host......................   : $BUILD_HOST
@@ -57,6 +55,14 @@ echo Optional Features:
      echo '   'Enable python interfaces..... : yes
    else
      echo '   'Enable python interfaces..... : no
+   fi
+
+   if test "$FORT_INTERFACES" = "1"; then
+     echo '   'Enable fortran interfaces.... : yes
+     echo Fortran compiler................   : $FC
+     echo Fortran compiler flags..........   : $FCFLAGS
+   else
+     echo '   'Enable fortran interfaces.... : no
    fi
 
 echo

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,7 +28,7 @@ cc_sources += navierstokes_3d_transient_sutherland.cpp
 
 BUILT_SOURCES = .license.stamp
 
-lib_LTLIBRARIES         = libmasa.la libfmasa.la
+lib_LTLIBRARIES         = libmasa.la
 library_includedir      = $(includedir)
 library_include_HEADERS = masa.h
 
@@ -43,9 +43,11 @@ libmasa_la_SOURCES      = $(cc_sources) $(h_sources)
 # MASA Fortran library
 # (Installs standalone)
 #----------------------
-
-libfmasa_la_LDFLAGS     = $(all_libraries) -release $(GENERIC_RELEASE)
-libfmasa_la_SOURCES     = masa.f90 $(libmasa_la_SOURCES)
+if FORT_ENABLED
+  lib_LTLIBRARIES        += libfmasa.la
+  libfmasa_la_LDFLAGS     = $(all_libraries) -release $(GENERIC_RELEASE)
+  libfmasa_la_SOURCES     = masa.f90 $(libmasa_la_SOURCES)
+endif
 
 #-----------------------
 # MASA (SWIG) Python interface (optional)
@@ -104,7 +106,9 @@ install-data-local: libfmasa.la
 	mkdir -p $(DESTDIR)$(libdir)
 	$(INSTALL_DATA) $(top_builddir)/src/masa.mod $(DESTDIR)$(libdir)/masa.mod
 
+if FORT_ENABLED
 uninstall-local: libfmasa.la
 	rm -rf $(DESTDIR)$(libdir)/masa.mod
+endif
 
 EXTRA_DIST   = lic_utils/update_license.pl .license.stamp masa.i

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -300,9 +300,12 @@ dist_check_SCRIPTS += c_init.sh
 TESTS              += c_init.sh
 TESTS              += $(TESTS_C)
 
+# If optional fortran interfaces are enabled:
+if FORT_ENABLED
 dist_check_SCRIPTS += f_init.sh
 TESTS              += f_init.sh
 TESTS              += $(TESTS_F)
+endif
 
 dist_check_SCRIPTS += finalize.sh
 TESTS              += finalize.sh

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -226,9 +226,11 @@ c_radiation_SOURCES      =  c_radiation.c
 c_radiation_LDADD        =  ../src/libmasa.la
 
 
+
 #------------------
 # Fortran Binaries
 #------------------
+if FORT_ENABLED
 TESTS_F         =
 check_PROGRAMS += $(TESTS_F)
 
@@ -280,6 +282,7 @@ TESTS_F                 +=  f_radiation
 f_radiation_SOURCES      =  f_radiation.F90
 f_radiation_LDADD        =  ../src/libfmasa.la
 
+endif
 
 #------------------
 # Regression suite


### PR DESCRIPTION
This takes a hit at #24. I changed my mind: the fortran bindings are not being built by default. Instead, the user needs to pass the flag, '--enable-fortran-interfaces' at configure time to build with fortran. 

I believe I hit all the dependencies necessary to make this cook well. This included disabling building examples and regression tests if the fortran is not enabled. 

Would love a 2nd pair of eyes... @RhysU or @koomie, etc. In particular, how do you folks feel about the configure.ac foo? Suggestions here would be welcome, this is where I feel least comfortable working. 