### PR TITLE
Fix convection term sign in AD Navier-Stokes

### DIFF
--- a/src/navierstokes_3d_incompressible.cpp
+++ b/src/navierstokes_3d_incompressible.cpp
@@ -121,7 +121,7 @@ Scalar MASA::navierstokes_3d_incompressible<Scalar>::eval_q_u(Scalar x1, Scalar 
     raw_value(
 
 	      // convective term
-	      divergence(U.outerproduct(U))
+	      -divergence(U.outerproduct(U))
 
 	      // pressure
 	      - P.derivatives()
@@ -160,7 +160,7 @@ Scalar MASA::navierstokes_3d_incompressible<Scalar>::eval_q_v(Scalar x1, Scalar 
     raw_value(
 
 	      // convective term
-	      divergence(U.outerproduct(U))
+	      -divergence(U.outerproduct(U))
 
 	      // pressure
 	      - P.derivatives()
@@ -199,7 +199,7 @@ Scalar MASA::navierstokes_3d_incompressible<Scalar>::eval_q_w(Scalar x1, Scalar 
     raw_value(
 
 	      // convective term
-	      divergence(U.outerproduct(U))
+	      -divergence(U.outerproduct(U))
 
 	      // pressure
 	      - P.derivatives()


### PR DESCRIPTION
@nicholasmalaya fixed a similar bug of mine in 3dfb350528486b9648666b0ea4f0537ffefb996d but missed this one.  Thanks to Clark C Pederson for catching it.