### PR TITLE
Fixed convective terms (sign error) in the Navier-Stokes AD solution and the AD example.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 Version 0.50.0 (In progress)
   * updated .gitignore
   * bug fix to --enable-fortran-interfaces Makefile.AM including .mod files
+  * bug fix in navierstokes_3d_incompressible to fix sign error in convection
+  * bug fix to import/examples/ to fix sign error in convection terms
 
 Version 0.44.0 (19 June, 2015)
 

--- a/src/import/examples/automatic_differentiation_example/incompressible_navier_stokes/source_terms.cpp
+++ b/src/import/examples/automatic_differentiation_example/incompressible_navier_stokes/source_terms.cpp
@@ -25,7 +25,7 @@ double eval_q_u(double x, double y, double z)
     raw_value(
 
 	      // convective term
-	      divergence(U.outerproduct(U))
+	      - divergence(U.outerproduct(U))
 
 	      // pressure
 	      - P.derivatives()
@@ -63,7 +63,7 @@ double eval_q_v(double x, double y, double z)
     raw_value(
 
 	      // convective term
-	      divergence(U.outerproduct(U))
+	      - divergence(U.outerproduct(U))
 
 	      // pressure
 	      - P.derivatives()
@@ -101,7 +101,7 @@ double eval_q_w(double x, double y, double z)
     raw_value(
 
 	      // convective term
-	      divergence(U.outerproduct(U))
+	      - divergence(U.outerproduct(U))
 
 	      // pressure
 	      - P.derivatives()

--- a/src/navierstokes_3d_incompressible.cpp
+++ b/src/navierstokes_3d_incompressible.cpp
@@ -121,7 +121,7 @@ Scalar MASA::navierstokes_3d_incompressible<Scalar>::eval_q_u(Scalar x1, Scalar 
     raw_value(
 
 	      // convective term
-	      divergence(U.outerproduct(U))
+	      - divergence(U.outerproduct(U))
 
 	      // pressure
 	      - P.derivatives()
@@ -160,7 +160,7 @@ Scalar MASA::navierstokes_3d_incompressible<Scalar>::eval_q_v(Scalar x1, Scalar 
     raw_value(
 
 	      // convective term
-	      divergence(U.outerproduct(U))
+	      - divergence(U.outerproduct(U))
 
 	      // pressure
 	      - P.derivatives()
@@ -199,7 +199,7 @@ Scalar MASA::navierstokes_3d_incompressible<Scalar>::eval_q_w(Scalar x1, Scalar 
     raw_value(
 
 	      // convective term
-	      divergence(U.outerproduct(U))
+	      - divergence(U.outerproduct(U))
 
 	      // pressure
 	      - P.derivatives()

--- a/tests/ad_ins.cpp
+++ b/tests/ad_ins.cpp
@@ -209,7 +209,7 @@ double evaluate_q (const NumberArray<NDIM, RawScalar>& xyz)
     raw_value(
 
 	      // convective term
-	      divergence(U.outerproduct(U))
+	      - divergence(U.outerproduct(U))
 
 	      // pressure
 	      - P.derivatives()


### PR DESCRIPTION
There was an inconsistency between the navierstokes_3d_incompressible manufactured solution and the navierstokes_3d_incompressible_homogeneous manufactured solution.  I corrected the convective terms to be negative, which matches the signs of the pressure and viscous terms.  This correction is also consistent with the derivation of a manufactured solution.