### PR TITLE
We can use a few OOM lower tolerance here

### DIFF
--- a/tests/ad_divgradsimple.cpp
+++ b/tests/ad_divgradsimple.cpp
@@ -57,8 +57,7 @@ typedef SecondDerivType ADType;
 template<typename Scalar>
 int run_test()
 {
-  // CCP: I hacked this threshold to be very lenient of errors
-  const Scalar thresh = 5000 * std::numeric_limits<Scalar>::epsilon();
+  const Scalar thresh = 50 * std::numeric_limits<Scalar>::epsilon();
   // parameters
   Scalar x, y, z;
 


### PR DESCRIPTION
This works for me with gcc; we could probably lose one more OOM but I don't want to bother double-checking on clang, intel, etc.