### PR TITLE
Remove use of deprecated AC_PROG_LIBTOOL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,8 @@ AC_SUBST(GENERIC_MINOR_VERSION)
 AC_SUBST(GENERIC_MICRO_VERSION)
 AC_SUBST(GENERIC_RELEASE)
 
+LT_INIT
+
 # define
 PACKAGE_DESCRIPTION="Manufactured Analytical Solutions Abstraction Library"
 AC_SUBST([PACKAGE_DESCRIPTION])
@@ -46,6 +48,9 @@ AX_CXX_MINOPT	# request minimum optimization level for CXX
 # Enable/Disable -Wall (Warn all)
 # ---------------------------------------------
 
+AC_PROG_CC
+AC_PROG_CXX
+
 AX_MASA_WARN_ALL
 
 # ------------------------------
@@ -53,9 +58,6 @@ AX_MASA_WARN_ALL
 # ------------------------------
 
 AC_DISABLE_STATIC
-
-AC_PROG_CC
-AC_PROG_CXX
 
 # ----------------------------
 # We may need the math library
@@ -72,12 +74,12 @@ AC_LANG_POP([C])
 FORTRAN_INTERFACES=0
 AC_ARG_ENABLE([fortran-interfaces], AC_HELP_STRING([--enable-fortran-interfaces],[enable fortran support]),
 [
-dnl set suffix to .F90 to get CPP support for testing vendor Fortran compiler
-AC_FC_SRCEXT([F90]) 
 dnl request minimum optimization level for FC
 AX_FC_MINOPT
 AC_PROG_F77()
 AC_PROG_FC()
+dnl set suffix to .F90 to get CPP support for testing vendor Fortran compiler
+AC_FC_SRCEXT([F90]) 
 FORTRAN_INTERFACES=1
 AC_DEFINE(FORTRAN_INTERFACES,1,[Define if Fortran interfaces enabled])
 ],[])
@@ -101,7 +103,6 @@ AC_SUBST(masa_optional_INCLUDES)
 #
 # now call libtool
 #
-AC_PROG_LIBTOOL
 AM_SANITY_CHECK
 
 

--- a/m4/common/ax_cxx_minopt.m4
+++ b/m4/common/ax_cxx_minopt.m4
@@ -52,7 +52,6 @@ AC_DEFUN([AX_CXX_MINOPT],
 
 if test "$ac_test_CXXFLAGS" != "set"; then
 
-  AC_LANG_PUSH([C++])
   AX_COMPILER_VENDOR
 
   # Baseline disable
@@ -78,7 +77,6 @@ if test "$ac_test_CXXFLAGS" != "set"; then
   esac	 
 
   AC_MSG_NOTICE([disabling C++ compiler optimizations ($CXXFLAGS)])
-  AC_LANG_POP([C++])
 
 else 
 

--- a/m4/common/ax_fc_minopt.m4
+++ b/m4/common/ax_fc_minopt.m4
@@ -57,7 +57,6 @@ AC_DEFUN([AX_FC_MINOPT],
 
 if test "$ac_test_FCFLAGS" != "set"; then
 
-  AC_LANG_PUSH([Fortran])
   AX_COMPILER_VENDOR
 
   # Baseline disable


### PR DESCRIPTION
1.  For some reason, the deprecated AC_PROG_LIBTOOL incorrectly deduces
    that my gfortran linker (ld) both does and does not support shared
    libraries.  Use of LT_INIT (the new hotness) fixes this, but I
    honestly don't know why.  That is to say, this patch fixes
    #32 for me.

2.  I updated two macros here that incorrectly PUSH and POP languages
    when all they're doing is setting some sensible defaults for CXXFLAGS.
    Perhaps we ought to do this instead:
    https://stackoverflow.com/questions/3116645/default-compiler-flags-with-autotools

3.  Autotools now basically always checks for a fortran compiler, even
    if FORT_ENABLED is false.  I can't seem to resolve this.  It doesn't
    seem to matter as there is currently a bug in AX_CODE_COVERAGE that
    dies if you don't have fortran anyway.

4.  This change introduces an "Expanded before required"
    (https://www.gnu.org/software/autoconf/manual/autoconf.html#Expanded-Before-Required)
    warning as a result of AC_FC_SRCEXT needing to have seen a fortran
    compiler.  It may be the case this warning is intractable:
    https://svn.mcs.anl.gov/repos/mpi/mpich2/trunk/confdb/aclocal_fc.m4
    Moving AC_PROG_FC and/or AC_PROG_F77 after AC_FC_SRCEXT results in
    an error saying that it hasn't seen a fortran compiler.  Go figure.