### PR TITLE
Update libtool macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,8 @@ AC_SUBST(GENERIC_MINOR_VERSION)
 AC_SUBST(GENERIC_MICRO_VERSION)
 AC_SUBST(GENERIC_RELEASE)
 
+LT_INIT
+
 # define
 PACKAGE_DESCRIPTION="Manufactured Analytical Solutions Abstraction Library"
 AC_SUBST([PACKAGE_DESCRIPTION])
@@ -46,6 +48,9 @@ AX_CXX_MINOPT	# request minimum optimization level for CXX
 # Enable/Disable -Wall (Warn all)
 # ---------------------------------------------
 
+AC_PROG_CC
+AC_PROG_CXX
+
 AX_MASA_WARN_ALL
 
 # ------------------------------
@@ -53,9 +58,6 @@ AX_MASA_WARN_ALL
 # ------------------------------
 
 AC_DISABLE_STATIC
-
-AC_PROG_CC
-AC_PROG_CXX
 
 # ----------------------------
 # We may need the math library
@@ -72,12 +74,12 @@ AC_LANG_POP([C])
 FORTRAN_INTERFACES=0
 AC_ARG_ENABLE([fortran-interfaces], AC_HELP_STRING([--enable-fortran-interfaces],[enable fortran support]),
 [
-dnl set suffix to .F90 to get CPP support for testing vendor Fortran compiler
-AC_FC_SRCEXT([F90]) 
 dnl request minimum optimization level for FC
 AX_FC_MINOPT
 AC_PROG_F77()
 AC_PROG_FC()
+dnl set suffix to .F90 to get CPP support for testing vendor Fortran compiler
+AC_FC_SRCEXT([F90]) 
 FORTRAN_INTERFACES=1
 AC_DEFINE(FORTRAN_INTERFACES,1,[Define if Fortran interfaces enabled])
 ],[])
@@ -101,7 +103,6 @@ AC_SUBST(masa_optional_INCLUDES)
 #
 # now call libtool
 #
-AC_PROG_LIBTOOL
 AM_SANITY_CHECK
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -23,8 +23,6 @@ AC_SUBST(GENERIC_MINOR_VERSION)
 AC_SUBST(GENERIC_MICRO_VERSION)
 AC_SUBST(GENERIC_RELEASE)
 
-LT_INIT
-
 # define
 PACKAGE_DESCRIPTION="Manufactured Analytical Solutions Abstraction Library"
 AC_SUBST([PACKAGE_DESCRIPTION])
@@ -76,8 +74,8 @@ AC_ARG_ENABLE([fortran-interfaces], AC_HELP_STRING([--enable-fortran-interfaces]
 [
 dnl request minimum optimization level for FC
 AX_FC_MINOPT
-AC_PROG_F77()
-AC_PROG_FC()
+AC_REQUIRE([AC_PROG_F77])
+AC_REQUIRE([AC_PROG_FC])
 dnl set suffix to .F90 to get CPP support for testing vendor Fortran compiler
 AC_FC_SRCEXT([F90]) 
 FORTRAN_INTERFACES=1
@@ -98,12 +96,6 @@ fi
 
 
 AC_SUBST(masa_optional_INCLUDES)
-
-
-#
-# now call libtool
-#
-AM_SANITY_CHECK
 
 
 # ---------------------------------------------
@@ -169,6 +161,15 @@ DX_PDF_FEATURE(ON)
 DX_PS_FEATURE(OFF)
 
 DX_INIT_DOXYGEN(MASA, doxygen/masa.dox, docs) 
+
+
+#
+# now call libtool
+#
+AM_SANITY_CHECK
+
+LT_INIT
+
 
 # Run scripts for regression tests
 AC_CONFIG_FILES(tests/py_init.sh, [chmod +x tests/py_init.sh])

--- a/m4/common/ax_cxx_minopt.m4
+++ b/m4/common/ax_cxx_minopt.m4
@@ -52,7 +52,6 @@ AC_DEFUN([AX_CXX_MINOPT],
 
 if test "$ac_test_CXXFLAGS" != "set"; then
 
-  AC_LANG_PUSH([C++])
   AX_COMPILER_VENDOR
 
   # Baseline disable
@@ -78,7 +77,6 @@ if test "$ac_test_CXXFLAGS" != "set"; then
   esac	 
 
   AC_MSG_NOTICE([disabling C++ compiler optimizations ($CXXFLAGS)])
-  AC_LANG_POP([C++])
 
 else 
 

--- a/m4/common/ax_fc_minopt.m4
+++ b/m4/common/ax_fc_minopt.m4
@@ -57,7 +57,6 @@ AC_DEFUN([AX_FC_MINOPT],
 
 if test "$ac_test_FCFLAGS" != "set"; then
 
-  AC_LANG_PUSH([Fortran])
   AX_COMPILER_VENDOR
 
   # Baseline disable


### PR DESCRIPTION
This extends #42 and fixes the fourth point there.

Point 3a, that we check for a Fortran compiler even when we shouldn't, seems nearly unfixable.

Point 3b isn't quite as bad as @dmcdougall made it sound: "AX_CODE_COVERAGE dies without Fortran support" is only true if you --enable-coverage; without that enabled we still configure and build and pass tests just fine on a system with no Fortran compilers.  So it looks like the fix will be as simple as "add an optional argument to supply a list of languages to AX_CODE_COVERAGE, then only check the languages on the list".