### PR TITLE
Adding Incomp NS with Boussinesq Bouyancy Solution

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Todd Oliver          (FANS/RANS)
 Marco Panesi         (Radiation)
 Gabriel Terejanu     (SMASA)
 Rhys Ulerich
+Jeremy Melvin        (Incomp NS with Boussinesq Buoyancy)
 
 ------------------------------------------------------------
 Misc: 

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Version 0.50.1 (IN PROGRESS)
 
   * Updates and bugfixes coming!
+  * Added Homogeneous Incompressible Navier Stokes with Boussinesq Buoyancy term
 
 Version 0.50.0 (27 February, 2017)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,6 +18,7 @@ cc_sources += ad_cns_3d_crossterms.cpp
 cc_sources += convdiff_steady_nosource_1d.cpp
 cc_sources += navierstokes_3d_incompressible.cpp
 cc_sources += navierstokes_3d_incompressible_homogeneous.cpp
+cc_sources += navierstokes_3d_incompbouss_homogeneous.cpp
 cc_sources += navierstokes_3d_transient_sutherland.cpp
 # do not edit this line! --l33t--
 

--- a/src/masa_core.cpp
+++ b/src/masa_core.cpp
@@ -159,6 +159,7 @@ int get_list_mms(std::vector<manufactured_solution<Scalar>*>& anim)
   anim.push_back(new convdiff_steady_nosource_1d<Scalar>());
   anim.push_back(new navierstokes_3d_incompressible<Scalar>());
   anim.push_back(new navierstokes_3d_incompressible_homogeneous<Scalar>());
+  anim.push_back(new navierstokes_3d_incompbouss_homogeneous<Scalar>());
   anim.push_back(new navierstokes_3d_transient_sutherland<Scalar>());
 #endif // HAVE_METAPHYSICL
 

--- a/src/masa_internal.h
+++ b/src/masa_internal.h
@@ -2169,6 +2169,49 @@ public:
 
 
 // ------------------------------------------------------
+// --------------- navierstokes_3d_incompbouss_homogeneous 
+// ------------------------------------------------------
+namespace MASA{
+template <typename Scalar>
+class navierstokes_3d_incompbouss_homogeneous : public manufactured_solution<Scalar>
+{
+  using manufactured_solution<Scalar>::pi;
+  using manufactured_solution<Scalar>::PI;
+
+private:
+  Scalar a;
+  Scalar b;
+  Scalar c;
+  Scalar d;
+  Scalar e;
+  Scalar beta;
+  Scalar gamma;
+  Scalar delta;
+  Scalar omega;
+  Scalar nu;
+  Scalar diff;
+  Scalar grav;
+  Scalar gradRho;
+  Scalar kx;
+  Scalar ky;
+  Scalar kz;
+
+public:
+  navierstokes_3d_incompbouss_homogeneous();
+  int init_var();
+  Scalar eval_q_u(Scalar,Scalar,Scalar);
+  Scalar eval_q_v(Scalar,Scalar,Scalar);
+  Scalar eval_q_w(Scalar,Scalar,Scalar);
+  Scalar eval_q_rho(Scalar,Scalar,Scalar);
+  Scalar eval_exact_u(Scalar,Scalar,Scalar);
+  Scalar eval_exact_v(Scalar,Scalar,Scalar);
+  Scalar eval_exact_w(Scalar,Scalar,Scalar);
+  Scalar eval_exact_p(Scalar,Scalar,Scalar);
+  Scalar eval_exact_rho(Scalar,Scalar,Scalar);
+};}
+
+
+// ------------------------------------------------------
 // --------------- navierstokes_3d_transient_sutherland 
 // ------------------------------------------------------
 namespace MASA{

--- a/src/navierstokes_3d_incompbouss_homogeneous.cpp
+++ b/src/navierstokes_3d_incompbouss_homogeneous.cpp
@@ -1,0 +1,406 @@
+// -*-c++-*-
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// MASA - Manufactured Analytical Solutions Abstraction Library
+//
+// Copyright (C) 2010,2011,2012,2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <masa_internal.h>
+
+#ifdef HAVE_METAPHYSICL
+
+#include <ad_masa.h>
+
+
+
+// Private methods declarations
+template <typename Scalar, typename Scalar2>
+Scalar helper_f(Scalar2 beta, Scalar2 kx, Scalar x);
+
+template <typename Scalar, typename Scalar2>
+Scalar helper_g(Scalar2 delta, Scalar2 ky, Scalar y);
+  
+template <typename Scalar, typename Scalar2>
+Scalar helper_h(Scalar2 gamma, Scalar2 kz, Scalar z);
+
+
+typedef ShadowNumber<double, long double> RawScalar;
+const unsigned int NDIM = 3;
+typedef DualNumber<RawScalar, NumberVector<NDIM, RawScalar> > FirstDerivType;
+typedef DualNumber<FirstDerivType, NumberVector<NDIM, FirstDerivType> > SecondDerivType;
+typedef SecondDerivType ADType;
+
+using namespace MASA;
+
+template <typename Scalar>
+MASA::navierstokes_3d_incompbouss_homogeneous<Scalar>::navierstokes_3d_incompbouss_homogeneous()
+{
+  this->mmsname = "navierstokes_3d_incompbouss_homogeneous";
+  this->dimension = 3;
+
+  this->register_var("a",&a);
+  this->register_var("b",&b);
+  this->register_var("c",&c);
+  this->register_var("d",&d);
+  this->register_var("e",&e);
+  this->register_var("beta",&beta);
+  this->register_var("gamma",&gamma);
+  this->register_var("delta",&delta);
+  this->register_var("omega",&omega);
+  this->register_var("nu",&nu);
+  this->register_var("kx",&kx);
+  this->register_var("kz",&kz);
+  this->register_var("ky",&ky);
+  this->register_var("grav",&grav);
+  this->register_var("gradRho",&gradRho);
+  this->register_var("diff",&diff);
+
+  this->init_var();
+
+} // done with constructor
+
+template <typename Scalar>
+int MASA::navierstokes_3d_incompbouss_homogeneous<Scalar>::init_var()
+{
+  int err = 0;
+
+  err += this->set_var("a",1.05);
+  err += this->set_var("b",2.15);
+  err += this->set_var("c",-3.2);
+  err += this->set_var("d",10.1);
+  err += this->set_var("e",4.6);
+  err += this->set_var("beta",2.2);
+  err += this->set_var("gamma",2.4);
+  err += this->set_var("delta",2.0);
+  err += this->set_var("omega",1.8);
+  err += this->set_var("nu",0.02);
+  err += this->set_var("kx",1);
+  err += this->set_var("kz",1);
+  err += this->set_var("ky",1);
+  err += this->set_var("grav",2.5); // Gravity should be positive for a downward acceleration
+  err += this->set_var("gradRho",-1.0); // gradRho typically has opposite sign to gravity
+  err += this->set_var("diff",0.02);
+
+  return err;
+
+} // done with init_var
+
+// ----------------------------------------
+// Source Terms
+// ----------------------------------------
+
+// u component of velocity source term
+template <typename Scalar>
+Scalar MASA::navierstokes_3d_incompbouss_homogeneous<Scalar>::eval_q_u(Scalar x1, Scalar y1, Scalar z1)
+{
+  typedef DualNumber<Scalar, NumberVector<NDIM, Scalar> > FirstDerivType;
+  typedef DualNumber<FirstDerivType, NumberVector<NDIM, FirstDerivType> > SecondDerivType;
+  typedef DualNumber<SecondDerivType, NumberVector<NDIM, SecondDerivType> > ThirdDerivType;
+  typedef ThirdDerivType ADScalar;
+
+  // Treat velocity as a vector
+  NumberVector<NDIM, ADScalar> U;
+
+  ADScalar x = ADScalar(x1,NumberVectorUnitVector<NDIM, 0, Scalar>::value());
+  ADScalar y = ADScalar(y1,NumberVectorUnitVector<NDIM, 1, Scalar>::value());
+  ADScalar z = ADScalar(z1,NumberVectorUnitVector<NDIM, 2, Scalar>::value());
+
+  // Arbitrary manufactured solutions
+  U[0]          = a * helper_f(beta,kx,x)                  * helper_g(delta,ky,y).derivatives()[1] * helper_h(gamma,kz,z).derivatives()[2];
+  U[1]          = b * helper_f(beta,kx,x).derivatives()[0] * helper_g(delta,ky,y)                  * helper_h(gamma,kz,z).derivatives()[2];
+  U[2]          = c * helper_f(beta,kx,x).derivatives()[0] * helper_g(delta,ky,y).derivatives()[1] * helper_h(gamma,kz,z);
+  ADScalar P    = d * helper_f(beta,kx,x)                  * helper_g(delta,ky,y)                  * helper_h(gamma,kz,z);
+
+  ADScalar RHO  = e * helper_f(gamma,kx,x)                 * helper_g(omega,ky,y).derivatives()[1]  * helper_h(delta,kz,z);
+
+  // Treat gravity as a vector
+  NumberVector<NDIM, ADScalar> G;
+
+  G[0] = 0.0;
+  G[1] = -grav;
+  G[2] = 0.0;
+
+  // NS equation residuals
+  NumberVector<NDIM, Scalar> Q_u = 
+    raw_value(
+
+	      // convective term
+	      -divergence(U.outerproduct(U))
+
+	      // pressure
+	      - P.derivatives()
+
+              // Boussinesq term
+              + RHO*G
+
+	      // dissipation
+	      + nu * divergence(gradient(U)));
+
+  return -Q_u[0];
+
+}
+
+// v component of velocity source term
+template <typename Scalar>
+Scalar MASA::navierstokes_3d_incompbouss_homogeneous<Scalar>::eval_q_v(Scalar x1, Scalar y1, Scalar z1)
+{
+  typedef DualNumber<Scalar, NumberVector<NDIM, Scalar> > FirstDerivType;
+  typedef DualNumber<FirstDerivType, NumberVector<NDIM, FirstDerivType> > SecondDerivType;
+  typedef DualNumber<SecondDerivType, NumberVector<NDIM, SecondDerivType> > ThirdDerivType;
+  typedef ThirdDerivType ADScalar;
+
+  // Treat velocity as a vector
+  NumberVector<NDIM, ADScalar> U;
+
+  ADScalar x = ADScalar(x1,NumberVectorUnitVector<NDIM, 0, Scalar>::value());
+  ADScalar y = ADScalar(y1,NumberVectorUnitVector<NDIM, 1, Scalar>::value());
+  ADScalar z = ADScalar(z1,NumberVectorUnitVector<NDIM, 2, Scalar>::value());
+
+  // Arbitrary manufactured solutions
+  U[0]          = a * helper_f(beta,kx,x)                  * helper_g(delta,ky,y).derivatives()[1] * helper_h(gamma,kz,z).derivatives()[2];
+  U[1]          = b * helper_f(beta,kx,x).derivatives()[0] * helper_g(delta,ky,y)                  * helper_h(gamma,kz,z).derivatives()[2];
+  U[2]          = c * helper_f(beta,kx,x).derivatives()[0] * helper_g(delta,ky,y).derivatives()[1] * helper_h(gamma,kz,z);
+  ADScalar P    = d * helper_f(beta,kx,x)                  * helper_g(delta,ky,y)                  * helper_h(gamma,kz,z);
+
+  ADScalar RHO  = e * helper_f(gamma,kx,x)                 * helper_g(omega,ky,y).derivatives()[1]  * helper_h(delta,kz,z);
+
+  // Treat gravity as a vector
+  NumberVector<NDIM, ADScalar> G;
+
+  G[0] = 0.0;
+  G[1] = -grav;
+  G[2] = 0.0;
+
+  // NS equation residuals
+  NumberVector<NDIM, Scalar> Q_u = 
+    raw_value(
+
+	      // convective term
+	      -divergence(U.outerproduct(U))
+
+	      // pressure
+	      - P.derivatives()
+    
+              // Boussinesq term
+              + RHO*G
+
+	      // dissipation
+	      + nu * divergence(gradient(U)));
+
+  return -Q_u[1];
+
+}
+
+// w component of velocity source term
+template <typename Scalar>
+Scalar MASA::navierstokes_3d_incompbouss_homogeneous<Scalar>::eval_q_w(Scalar x1, Scalar y1, Scalar z1)
+{
+  typedef DualNumber<Scalar, NumberVector<NDIM, Scalar> > FirstDerivType;
+  typedef DualNumber<FirstDerivType, NumberVector<NDIM, FirstDerivType> > SecondDerivType;
+  typedef DualNumber<SecondDerivType, NumberVector<NDIM, SecondDerivType> > ThirdDerivType;
+  typedef ThirdDerivType ADScalar;
+
+  // Treat velocity as a vector
+  NumberVector<NDIM, ADScalar> U;
+
+  ADScalar x = ADScalar(x1,NumberVectorUnitVector<NDIM, 0, Scalar>::value());
+  ADScalar y = ADScalar(y1,NumberVectorUnitVector<NDIM, 1, Scalar>::value());
+  ADScalar z = ADScalar(z1,NumberVectorUnitVector<NDIM, 2, Scalar>::value());
+
+  // Arbitrary manufactured solutions
+  U[0]          = a * helper_f(beta,kx,x)                  * helper_g(delta,ky,y).derivatives()[1] * helper_h(gamma,kz,z).derivatives()[2];
+  U[1]          = b * helper_f(beta,kx,x).derivatives()[0] * helper_g(delta,ky,y)                  * helper_h(gamma,kz,z).derivatives()[2];
+  U[2]          = c * helper_f(beta,kx,x).derivatives()[0] * helper_g(delta,ky,y).derivatives()[1] * helper_h(gamma,kz,z);
+  ADScalar P    = d * helper_f(beta,kx,x)                  * helper_g(delta,ky,y)                  * helper_h(gamma,kz,z);
+
+  ADScalar RHO  = e * helper_f(gamma,kx,x)                 * helper_g(omega,ky,y).derivatives()[1]  * helper_h(delta,kz,z);
+
+  // Treat gravity as a vector
+  NumberVector<NDIM, ADScalar> G;
+
+  G[0] = 0.0;
+  G[1] = -grav;
+  G[2] = 0.0;
+
+  // NS equation residuals
+  NumberVector<NDIM, Scalar> Q_u = 
+    raw_value(
+
+	      // convective term
+	      -divergence(U.outerproduct(U))
+
+	      // pressure
+	      - P.derivatives()
+
+              // Boussinesq term
+              + RHO*G
+
+	      // dissipation
+	      + nu * divergence(gradient(U)));
+
+  return -Q_u[2];
+
+}
+
+// JAM: Added density source term
+template <typename Scalar>
+Scalar MASA::navierstokes_3d_incompbouss_homogeneous<Scalar>::eval_q_rho(Scalar x1, Scalar y1, Scalar z1)
+{
+  typedef DualNumber<Scalar, NumberVector<NDIM, Scalar> > FirstDerivType;
+  typedef DualNumber<FirstDerivType, NumberVector<NDIM, FirstDerivType> > SecondDerivType;
+  typedef DualNumber<SecondDerivType, NumberVector<NDIM, SecondDerivType> > ThirdDerivType;
+  typedef ThirdDerivType ADScalar;
+
+  // Treat velocity as a vector
+  NumberVector<NDIM, ADScalar> U;
+
+  ADScalar x = ADScalar(x1,NumberVectorUnitVector<NDIM, 0, Scalar>::value());
+  ADScalar y = ADScalar(y1,NumberVectorUnitVector<NDIM, 1, Scalar>::value());
+  ADScalar z = ADScalar(z1,NumberVectorUnitVector<NDIM, 2, Scalar>::value());
+
+  // Arbitrary manufactured solutions
+  U[0]          = a * helper_f(beta,kx,x)                  * helper_g(delta,ky,y).derivatives()[1] * helper_h(gamma,kz,z).derivatives()[2];
+  U[1]          = b * helper_f(beta,kx,x).derivatives()[0] * helper_g(delta,ky,y)                  * helper_h(gamma,kz,z).derivatives()[2];
+  U[2]          = c * helper_f(beta,kx,x).derivatives()[0] * helper_g(delta,ky,y).derivatives()[1] * helper_h(gamma,kz,z);
+  ADScalar P    = d * helper_f(beta,kx,x)                  * helper_g(delta,ky,y)                  * helper_h(gamma,kz,z);
+
+  ADScalar RHO  = e * helper_f(gamma,kx,x)                 * helper_g(omega,ky,y).derivatives()[1]  * helper_h(delta,kz,z);
+
+  // NS equation residuals
+  Scalar Q_rho = 
+    raw_value(
+
+	      // convective term
+	      -divergence(RHO*U)
+
+	      // Coupling Term (with constant density gradient)
+	      - gradRho*U[1]
+
+	      // dissipation
+	      + diff * divergence(gradient(RHO)));
+
+  return -Q_rho;
+
+}
+
+
+
+// ----------------------------------------
+// Analytical Terms
+// ----------------------------------------
+
+// helper functions
+template <typename Scalar, typename Scalar2>
+Scalar helper_f(Scalar2 beta, Scalar2 kx, Scalar x)
+{
+  Scalar func;
+  func = 1/(beta+std::sin(kx*x));
+  return func;
+}
+
+template <typename Scalar, typename Scalar2>
+Scalar helper_g(Scalar2 delta, Scalar2 ky, Scalar y)
+{
+  Scalar func;
+  func = 1/(delta+std::sin(ky*y));
+  return func;
+}
+  
+template <typename Scalar, typename Scalar2>
+Scalar helper_h(Scalar2 gamma, Scalar2 kz, Scalar z)
+{
+  Scalar func;
+  func = 1/(gamma+std::sin(kz*z));
+  return func;
+}
+
+//
+// main functions
+// 
+
+// example of a public method called from eval_exact_t
+template <typename Scalar>
+Scalar MASA::navierstokes_3d_incompbouss_homogeneous<Scalar>::eval_exact_u(Scalar x, Scalar y1, Scalar z1)
+{
+  typedef DualNumber<Scalar, Scalar> OneDDerivType;
+  OneDDerivType y = OneDDerivType(y1,1);
+  OneDDerivType z = OneDDerivType(z1,1);
+ 
+  Scalar exact_u;
+  exact_u =   a *  helper_f(beta,kx,x) * helper_g(delta,ky,y).derivatives() *  helper_h(gamma,kz,z).derivatives();
+  return exact_u;
+}
+
+// public method
+template <typename Scalar>
+Scalar MASA::navierstokes_3d_incompbouss_homogeneous<Scalar>::eval_exact_v(Scalar x1, Scalar y, Scalar z1)
+{
+  typedef DualNumber<Scalar, Scalar> OneDDerivType;
+  OneDDerivType x = OneDDerivType(x1,1);
+  OneDDerivType z = OneDDerivType(z1,1);
+
+  Scalar exact_v;
+  exact_v = b * helper_f(beta,kx,x).derivatives() *  helper_g(delta,ky,y) * helper_h(gamma,kz,z).derivatives();
+  return exact_v;
+}
+
+// public method
+template <typename Scalar>
+Scalar MASA::navierstokes_3d_incompbouss_homogeneous<Scalar>::eval_exact_w(Scalar x1, Scalar y1, Scalar z)
+{
+  typedef DualNumber<Scalar, Scalar> OneDDerivType;
+  OneDDerivType x = OneDDerivType(x1,1);
+  OneDDerivType y = OneDDerivType(y1,1);
+
+  Scalar exact_w;
+  exact_w = c * helper_f(beta,kx,x).derivatives() * helper_g(delta,ky,y).derivatives() *  helper_h(gamma,kz,z);
+  return exact_w;
+}
+
+// public method
+template <typename Scalar>
+Scalar MASA::navierstokes_3d_incompbouss_homogeneous<Scalar>::eval_exact_p(Scalar x, Scalar y, Scalar z)
+{
+
+  Scalar P = d *  helper_f(beta,kx,x) * helper_g(delta,ky,y) *  helper_h(gamma,kz,z);
+  return P;
+}
+
+// public method
+template <typename Scalar>
+Scalar MASA::navierstokes_3d_incompbouss_homogeneous<Scalar>::eval_exact_rho(Scalar x, Scalar y1, Scalar z)
+{
+  typedef DualNumber<Scalar, Scalar> OneDDerivType;
+  OneDDerivType y = OneDDerivType(y1,1);
+
+  Scalar exact_rho;
+  exact_rho = e * helper_f(gamma,kx,x) * helper_g(omega,ky,y).derivatives() * helper_h(delta,kz,z);
+  return exact_rho;
+}
+
+
+// ----------------------------------------
+// Template Instantiation(s)
+// ----------------------------------------
+
+MASA_INSTANTIATE_ALL(MASA::navierstokes_3d_incompbouss_homogeneous);
+
+
+#endif // HAVE_METAPHYSICL

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -163,6 +163,10 @@ TESTS_CXX_AD             +=  ad_divgradsimple
 ad_divgradsimple_SOURCES  =  ad_divgradsimple.cpp
 ad_divgradsimple_LDADD    =  ../src/libmasa.la
 
+TESTS_CXX_AD             +=  ns3d_incompbouss
+ns3d_incompbouss_SOURCES  =  ns3d_incompbouss.cpp
+ns3d_incompbouss_LDADD    =  ../src/libmasa.la
+
 #------------
 # C Binaries
 #------------

--- a/tests/ns3d_incompbouss.cpp
+++ b/tests/ns3d_incompbouss.cpp
@@ -1,0 +1,427 @@
+// -*-c++-*-
+//
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// MASA - Manufactured Analytical Solutions Abstraction Library
+//
+// Copyright (C) 2010,2011,2012,2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+//
+// ad_cns.cpp: test the incompressible navier stokes equations are roughly identical to 
+//              the source terms generated from AD
+//
+// $Id: $
+//--------------------------------------------------------------------------
+//--------------------------------------------------------------------------
+
+#include <iostream>
+#include <config.h>
+
+#ifdef HAVE_METAPHYSICL
+
+#include <tests.h>
+#include "ad_masa.h"
+
+double my_beta;
+double my_gamma;
+double my_delta;
+double my_omega;
+double kx;
+double ky;
+double kz;
+
+double a;
+double b;
+double c;
+double d;
+double e;
+double nu;
+double grav;
+double gradRho;
+double diff;
+
+// typedef double RawScalar;
+typedef ShadowNumber<double, long double> RawScalar;
+
+const unsigned int NDIM = 3;
+
+typedef DualNumber<RawScalar, NumberVector<NDIM, RawScalar> > FirstDerivType;
+typedef DualNumber<FirstDerivType, NumberVector<NDIM, FirstDerivType> > SecondDerivType;
+
+typedef SecondDerivType ADType;
+// typedef FirstDerivType ADType;
+
+template <std::size_t NDIM, typename RawScalar>
+double evaluate_qu (const NumberVector<NDIM, RawScalar>& xyz);
+
+template <std::size_t NDIM, typename RawScalar>
+double evaluate_qv (const NumberVector<NDIM, RawScalar>& xyz);
+
+template <std::size_t NDIM, typename RawScalar>
+double evaluate_qw (const NumberVector<NDIM, RawScalar>& xyz);
+
+template <std::size_t NDIM, typename RawScalar>
+double evaluate_qr (const NumberVector<NDIM, RawScalar>& xyz);
+
+using namespace MASA;
+
+int main(void)
+{
+  int err = 0;
+  int N   = 4; // mesh pts. in x and y and z
+  double su,sv,sw,sr,s2u,s2v,s2w,s2r;
+  double unorm, vnorm, wnorm, rnorm;
+  double unorm_max, vnorm_max, wnorm_max, rnorm_max;
+  double urnorm_max = 0., vrnorm_max = 0., wrnorm_max = 0., rrnorm_max = 0.;
+
+  unorm_max = 0;
+  vnorm_max = 0;
+  wnorm_max = 0;
+  rnorm_max = 0;
+
+  // initialize the problem in MASA
+  err += masa_init("test_bouss","navierstokes_3d_incompbouss_homogeneous");
+  err += masa_sanity_check();
+
+  my_beta = masa_get_param("beta");
+  my_gamma = masa_get_param("gamma");
+  my_delta = masa_get_param("delta");
+  my_omega = masa_get_param("omega");
+  kx = masa_get_param("kx");
+  ky = masa_get_param("ky");
+  kz = masa_get_param("kz");
+  a = masa_get_param("a");
+  b = masa_get_param("b");
+  c = masa_get_param("c");
+  d = masa_get_param("d");
+  e = masa_get_param("e");
+  nu = masa_get_param("nu");
+  grav = masa_get_param("grav");
+  gradRho = masa_get_param("gradRho");
+  diff = masa_get_param("diff");
+
+  // we first set up the DualNumbers that correspond to independent
+  // variables, spatial coordinates x and y and z
+
+  NumberVector<NDIM, RawScalar> xyz;
+
+  // the input argument xyz is another NumberVector 
+  // a vector just like Q_rho_u, a spatial location rather 
+  // than a vector-valued forcing function.
+  double h = 1.0/N;
+  for (int k=0; k != N+1; ++k)
+    {
+      xyz[2] = k*h;
+
+      for (int i=0; i != N+1; ++i)
+	{
+	  //
+	  xyz[0] = i*h;
+	  
+	  // Under the hood:
+	  // xy[0] = ADType(FirstDerivType(i*h, xvec), xvec);
+
+	  for (int j=0; j != N+1; ++j)
+	    {
+	      xyz[1] = j*h;
+
+	      // evaluate masa source terms
+	      su  = masa_eval_source_u<double>(i*h,j*h,k*h);
+	      sv  = masa_eval_source_v<double>(i*h,j*h,k*h);
+	      sw  = masa_eval_source_w<double>(i*h,j*h,k*h);
+              sr  = masa_eval_source_rho<double>(i*h,j*h,k*h);
+
+	      // AD source terms
+	      s2u = evaluate_qu(xyz);
+	      s2v = evaluate_qv(xyz);
+              s2w = evaluate_qw(xyz);
+              s2r = evaluate_qr(xyz);
+
+	      unorm = fabs(su-s2u);	  
+	      vnorm = fabs(sv-s2v);
+              wnorm = fabs(sw-s2w);
+              rnorm = fabs(sr-s2r);
+
+	      double urnorm = fabs(su-s2u)/std::max(su,s2u);	  
+	      double vrnorm = fabs(sv-s2v)/std::max(sv,s2v);
+              double wrnorm = fabs(sw-s2w)/std::max(sw,s2w);
+              double rrnorm = fabs(sr-s2r)/std::max(sr,s2r);
+
+	      unorm_max = std::max(unorm, unorm_max);
+	      vnorm_max = std::max(vnorm, vnorm_max);
+              wnorm_max = std::max(wnorm, wnorm_max);
+              rnorm_max = std::max(rnorm, rnorm_max);
+
+	      urnorm_max = std::max(urnorm, urnorm_max);
+	      vrnorm_max = std::max(vrnorm, vrnorm_max);
+              wrnorm_max = std::max(wrnorm, wrnorm_max);
+              rrnorm_max = std::max(rrnorm, rrnorm_max);
+
+	    }
+	}
+    }//done with 'k' index
+
+  // steady as she goes...
+  return 0;
+
+}
+
+template <typename Scalar>
+Scalar helper_f(Scalar x)
+{
+  Scalar func;
+  func = 1/(my_beta+std::sin(kx*x));
+  return func;
+}
+
+template <typename Scalar>
+Scalar helper_frho(Scalar x)
+{
+  Scalar func;
+  func = 1/(my_gamma+std::sin(kx*x));
+  return func;
+}
+
+template <typename Scalar>
+Scalar helper_g(Scalar y)
+{
+  Scalar func;
+  func = 1/(my_delta+std::sin(ky*y));
+  return func;
+}
+
+template <typename Scalar>
+Scalar helper_grho(Scalar y)
+{
+  Scalar func;
+  func = 1/(my_omega+std::sin(ky*y));
+  return func;
+}
+
+template <typename Scalar>
+Scalar helper_h(Scalar z)
+{
+  Scalar func;
+  func = 1/(my_gamma+std::sin(kz*z));
+  return func;
+}
+
+template <typename Scalar>
+Scalar helper_hrho(Scalar z)
+{
+  Scalar func;
+  func = 1/(my_delta+std::sin(kz*z));
+  return func;
+}
+
+
+// Note: ADScalar needs to be a FirstDerivType or better since we have
+// first derivatives here.  Adding diffusion will require a
+// SecondDerivType or better
+
+template <std::size_t NDIM, typename RawScalar>
+double evaluate_qu (const NumberVector<NDIM, RawScalar>& xyz)
+{
+  typedef DualNumber<RawScalar, NumberVector<NDIM, RawScalar> > FirstDerivType;
+  typedef DualNumber<FirstDerivType, NumberVector<NDIM, FirstDerivType> > SecondDerivType;
+  typedef DualNumber<SecondDerivType, NumberVector<NDIM, SecondDerivType> > ThirdDerivType;
+  typedef ThirdDerivType ADScalar;
+
+  // Treat velocity as a vector
+  NumberVector<NDIM, ADScalar> U;
+
+  ADScalar x = ADScalar(xyz[0],NumberVectorUnitVector<NDIM, 0, RawScalar>::value());
+  ADScalar y = ADScalar(xyz[1],NumberVectorUnitVector<NDIM, 1, RawScalar>::value());
+  ADScalar z = ADScalar(xyz[2],NumberVectorUnitVector<NDIM, 2, RawScalar>::value());
+
+  // Arbitrary manufactured solutions
+  U[0]          = a * helper_f(x)                  * helper_g(y).derivatives()[1]     * helper_h(z).derivatives()[2];
+  U[1]          = b * helper_f(x).derivatives()[0] * helper_g(y)                      * helper_h(z).derivatives()[2];
+  U[2]          = c * helper_f(x).derivatives()[0] * helper_g(y).derivatives()[1]     * helper_h(z);
+  ADScalar P    = d * helper_f(x)                  * helper_g(y)                      * helper_h(z);
+  ADScalar RHO  = e * helper_frho(x)               * helper_grho(y).derivatives()[1]  * helper_hrho(z);
+
+  // Treat gravity as a vector
+  NumberVector<NDIM, ADScalar> G;
+
+  G[0] = 0.0;
+  G[1] = -grav;
+  G[2] = 0.0;
+
+  // NS equation residuals
+  NumberVector<NDIM, RawScalar> Q_u = 
+    raw_value(
+
+	      // convective term
+	      - divergence(U.outerproduct(U))
+
+	      // pressure
+	      - P.derivatives()
+
+              // Boussinesq term
+              + RHO*G
+
+	      // dissipation
+	      + nu * divergence(gradient(U)));
+
+  return raw_value(Q_u[0]);
+}
+
+template <std::size_t NDIM, typename RawScalar>
+double evaluate_qv (const NumberVector<NDIM, RawScalar>& xyz)
+{
+  typedef DualNumber<RawScalar, NumberVector<NDIM, RawScalar> > FirstDerivType;
+  typedef DualNumber<FirstDerivType, NumberVector<NDIM, FirstDerivType> > SecondDerivType;
+  typedef DualNumber<SecondDerivType, NumberVector<NDIM, SecondDerivType> > ThirdDerivType;
+  typedef ThirdDerivType ADScalar;
+
+  // Treat velocity as a vector
+  NumberVector<NDIM, ADScalar> U;
+
+  ADScalar x = ADScalar(xyz[0],NumberVectorUnitVector<NDIM, 0, RawScalar>::value());
+  ADScalar y = ADScalar(xyz[1],NumberVectorUnitVector<NDIM, 1, RawScalar>::value());
+  ADScalar z = ADScalar(xyz[2],NumberVectorUnitVector<NDIM, 2, RawScalar>::value());
+
+  // Arbitrary manufactured solutions
+  U[0]          = a * helper_f(x)                  * helper_g(y).derivatives()[1]     * helper_h(z).derivatives()[2];
+  U[1]          = b * helper_f(x).derivatives()[0] * helper_g(y)                      * helper_h(z).derivatives()[2];
+  U[2]          = c * helper_f(x).derivatives()[0] * helper_g(y).derivatives()[1]     * helper_h(z);
+  ADScalar P    = d * helper_f(x)                  * helper_g(y)                      * helper_h(z);
+  ADScalar RHO  = e * helper_frho(x)               * helper_grho(y).derivatives()[1]  * helper_hrho(z);
+  
+  // Treat gravity as a vector
+  NumberVector<NDIM, ADScalar> G;
+
+  G[0] = 0.0;
+  G[1] = -grav;
+  G[2] = 0.0;
+
+  // NS equation residuals
+  NumberVector<NDIM, RawScalar> Q_u =
+    raw_value(
+
+              // convective term
+              - divergence(U.outerproduct(U))
+
+              // pressure
+              - P.derivatives()
+
+              // Boussinesq term
+              + RHO*G
+
+              // dissipation
+              + nu * divergence(gradient(U)));
+
+  return raw_value(Q_u[1]);
+}
+
+template <std::size_t NDIM, typename RawScalar>
+double evaluate_qw (const NumberVector<NDIM, RawScalar>& xyz)
+{
+  typedef DualNumber<RawScalar, NumberVector<NDIM, RawScalar> > FirstDerivType;
+  typedef DualNumber<FirstDerivType, NumberVector<NDIM, FirstDerivType> > SecondDerivType;
+  typedef DualNumber<SecondDerivType, NumberVector<NDIM, SecondDerivType> > ThirdDerivType;
+  typedef ThirdDerivType ADScalar;
+
+  // Treat velocity as a vector
+  NumberVector<NDIM, ADScalar> U;
+
+  ADScalar x = ADScalar(xyz[0],NumberVectorUnitVector<NDIM, 0, RawScalar>::value());
+  ADScalar y = ADScalar(xyz[1],NumberVectorUnitVector<NDIM, 1, RawScalar>::value());
+  ADScalar z = ADScalar(xyz[2],NumberVectorUnitVector<NDIM, 2, RawScalar>::value());
+
+  // Arbitrary manufactured solutions
+  U[0]          = a * helper_f(x)                  * helper_g(y).derivatives()[1]     * helper_h(z).derivatives()[2];
+  U[1]          = b * helper_f(x).derivatives()[0] * helper_g(y)                      * helper_h(z).derivatives()[2];
+  U[2]          = c * helper_f(x).derivatives()[0] * helper_g(y).derivatives()[1]     * helper_h(z);
+  ADScalar P    = d * helper_f(x)                  * helper_g(y)                      * helper_h(z);
+  ADScalar RHO  = e * helper_frho(x)               * helper_grho(y).derivatives()[1]  * helper_hrho(z);
+  
+  // Treat gravity as a vector
+  NumberVector<NDIM, ADScalar> G;
+
+  G[0] = 0.0;
+  G[1] = -grav;
+  G[2] = 0.0;
+
+  // NS equation residuals
+  NumberVector<NDIM, RawScalar> Q_u =
+    raw_value(
+
+              // convective term
+              - divergence(U.outerproduct(U))
+
+              // pressure
+              - P.derivatives()
+
+              // Boussinesq term
+              + RHO*G
+
+              // dissipation
+              + nu * divergence(gradient(U)));
+
+  return raw_value(Q_u[2]);
+}
+
+template <std::size_t NDIM, typename RawScalar>
+double evaluate_qr (const NumberVector<NDIM, RawScalar>& xyz)
+{
+  typedef DualNumber<RawScalar, NumberVector<NDIM, RawScalar> > FirstDerivType;
+  typedef DualNumber<FirstDerivType, NumberVector<NDIM, FirstDerivType> > SecondDerivType;
+  typedef DualNumber<SecondDerivType, NumberVector<NDIM, SecondDerivType> > ThirdDerivType;
+  typedef ThirdDerivType ADScalar;
+
+  // Treat velocity as a vector
+  NumberVector<NDIM, ADScalar> U;
+
+  ADScalar x = ADScalar(xyz[0],NumberVectorUnitVector<NDIM, 0, RawScalar>::value());
+  ADScalar y = ADScalar(xyz[1],NumberVectorUnitVector<NDIM, 1, RawScalar>::value());
+  ADScalar z = ADScalar(xyz[2],NumberVectorUnitVector<NDIM, 2, RawScalar>::value());
+
+  // Arbitrary manufactured solutions
+  U[0]          = a * helper_f(x)                  * helper_g(y).derivatives()[1]     * helper_h(z).derivatives()[2];
+  U[1]          = b * helper_f(x).derivatives()[0] * helper_g(y)                      * helper_h(z).derivatives()[2];
+  U[2]          = c * helper_f(x).derivatives()[0] * helper_g(y).derivatives()[1]     * helper_h(z);
+  ADScalar P    = d * helper_f(x)                  * helper_g(y)                      * helper_h(z);
+  ADScalar RHO  = e * helper_frho(x)               * helper_grho(y).derivatives()[1]  * helper_hrho(z);
+  
+  // NS equation residuals
+  double Q_rho =
+    raw_value(
+
+              // convective term
+              - divergence(RHO*U)
+
+              // Boussinesq term
+              - gradRho*U[1]
+
+              // dissipation
+              + diff * divergence(gradient(RHO)));
+
+  return Q_rho;
+}
+
+#else // HAVE_METAPHYSICL
+
+int main(void)
+{
+  return 77; // Autotools code for "skip test"
+}
+
+#endif // HAVE_METAPHYSICL


### PR DESCRIPTION
This is the addition of a new solution for the incomp Navier-Stokes with a Boussinesq Buoyancy.  At this stage the gravity is assumed to be in the y-direction, but that can easily be generalized going forward.  This has been tested and verified and successfully used to verify a stratified homogeneous solution in PoongBack.  Let me know if you need documentation for the formulation or have any questions.  Thanks.