### PR TITLE
Make f_insh optional test contingent upon MetaPhysicL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -94,8 +94,8 @@ if (test x$HAVE_METAPHYSICL = x1); then
   masa_optional_INCLUDES="$METAPHYSICL_CPPFLAGS $masa_optional_INCLUDES"
 fi
 
-
 AC_SUBST(masa_optional_INCLUDES)
+AM_CONDITIONAL(METAPHYSICL_ENABLED,[test "x$HAVE_METAPHYSICL" = x1])
 
 
 # ---------------------------------------------

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -17,7 +17,12 @@ noinst_PROGRAMS += euler_transient heat_example switch ablation_example
 noinst_PROGRAMS += c_heat_example c_euler_example c_laplace_example sod
 
 if FORT_ENABLED
-noinst_PROGRAMS += f_cns f_cns_4d f_euler f_laplace f_insh
+noinst_PROGRAMS += f_cns f_cns_4d f_euler f_laplace
+
+if METAPHYSICL_ENABLED
+noinst_PROGRAMS += f_insh
+endif
+
 endif
 
 noinst_PROGRAMS += cp_gaussian
@@ -85,9 +90,11 @@ f_cns_4d_SOURCES          = f_cns_4d.f90
 f_cns_4d_LDADD            = -lfmasa
 f_cns_4d_LIBTOOLFLAGS     = --tag=FC
 
+if METAPHYSICL_ENABLED
 f_insh_SOURCES             = f_insh.f90
 f_insh_LDADD               = -lfmasa
 f_insh_LIBTOOLFLAGS        = --tag=FC
+endif
 
 example_DATA             += f_euler.f90
 
@@ -126,8 +133,12 @@ TESTS                     += f_init.sh            \
                              f_laplace            \
                              f_euler              \
                              f_cns                \
-                             f_cns_4d             \
-                             f_insh 
+                             f_cns_4d             
+
+if METAPHYSICL_ENABLED
+TESTS                     += f_insh 
+endif
+
 endif
 
 TESTS                     += finalize.sh


### PR DESCRIPTION
This test uses the automatic differentiation (AD) capability in MASA, as well as the F90 bindings. While this test was already dependent on the latter, it was not on the former. I've added define pragmas to the Makefile.am to prevent building this test if MetaPhysicL is not enabled. 

Another way this could go would be to skip the test, with a return code of 77 and using in-line pragmas. However, I do not have a means to pass the C-preprocessor across fortran code right now in masa, and I'm unsure how to do this in automake. Would probably be a nice feature to add, but since it will not add any value to this bug, I would rather skip that for this ticket. 

This patch now appears to be correctly *not* building the f_insh example when fortran bindings are enabled but MetaPhysicL is not present. 