### PR TITLE
Fix floating point exception during initialization in fans_sa_steady_wall_bounded

### DIFF
--- a/src/fans_sa.cpp
+++ b/src/fans_sa.cpp
@@ -474,7 +474,7 @@ int MASA::fans_sa_steady_wall_bounded<Scalar>::init_var()
   err += this->set_var("b",0.33);
 
   // this sets all constants set from parameters
-  update(0,0);
+  update(std::numeric_limits<Scalar>::epsilon(),std::numeric_limits<Scalar>::epsilon());
 
   return err;
 }


### PR DESCRIPTION
Initializing with `x=0,y=0` causes a `pow(0,-num)` in `fans_sa_steady_wall_bounded`. Maybe there is a better solution, but we chose to pass in `epsilon` instead of `0`.